### PR TITLE
refactor: streamline member merging logic and enhance conflict detection

### DIFF
--- a/frontend/src/components/members/MergeMember.tsx
+++ b/frontend/src/components/members/MergeMember.tsx
@@ -19,17 +19,13 @@ import {
 } from "@heroicons/react/24/outline";
 import { MemberModel } from "@/models/Member";
 import { MetadataContext } from "@/lib/context";
-import { MetadataSelectModel } from "@/models/Metadata";
-import { updateMember, deleteMember } from "@/lib/members";
 import {
-  collection,
-  DocumentReference,
-  getDocs,
-  Timestamp,
-  updateDoc,
-  doc,
-} from "firebase/firestore";
-import { firestore } from "@/lib/firebase";
+  detectConflicts as detectMergeConflicts,
+  buildMergedMember,
+  mergeMembers,
+  getMetadataDisplayValue,
+  ConflictResolutions,
+} from "@/lib/merge";
 import { promiseToast } from "@/helper/Toast";
 
 export default function MergeMember({
@@ -51,69 +47,15 @@ export default function MergeMember({
   );
   const [confirmName, setConfirmName] = useState("");
   const [showConflicts, setShowConflicts] = useState(false);
-  const [conflictResolutions, setConflictResolutions] = useState<{
-    [key: string]: "primary" | "selected";
-  }>({});
+  const [conflictResolutions, setConflictResolutions] =
+    useState<ConflictResolutions>({});
   // Loading: not loading = false
   const [loading, setLoading] = useState(false);
 
   // When the selected member and primary have conflicting fields
   const detectConflicts = () => {
     if (!selectedMember) return [];
-
-    const conflicts: Array<{
-      field: string;
-      label: string;
-      primaryValue: any;
-      selectedValue: any;
-    }> = [];
-
-    // check name conflict
-    if (
-      primaryMember.name &&
-      selectedMember.name &&
-      primaryMember.name !== selectedMember.name
-    ) {
-      conflicts.push({
-        field: "name",
-        label: "Name",
-        primaryValue: primaryMember.name,
-        selectedValue: selectedMember.name,
-      });
-    }
-
-    // Check email conflict
-    if (
-      primaryMember.email &&
-      selectedMember.email &&
-      primaryMember.email !== selectedMember.email
-    ) {
-      conflicts.push({
-        field: "email",
-        label: "Email",
-        primaryValue: primaryMember.email,
-        selectedValue: selectedMember.email,
-      });
-    }
-
-    // Check metadata conflicts
-    if (metadata) {
-      metadata.forEach((m) => {
-        const primaryValue = primaryMember.metadata?.[m.id];
-        const selectedValue = selectedMember.metadata?.[m.id];
-
-        if (primaryValue && selectedValue && primaryValue !== selectedValue) {
-          conflicts.push({
-            field: `metadata.${m.id}`,
-            label: m.key,
-            primaryValue: getMetadataDisplayValue(m, primaryValue),
-            selectedValue: getMetadataDisplayValue(m, selectedValue),
-          });
-        }
-      });
-    }
-
-    return conflicts;
+    return detectMergeConflicts(primaryMember, selectedMember, metadata);
   };
 
   const handleConflict = () => {
@@ -138,125 +80,18 @@ export default function MergeMember({
     if (!selectedMember) return;
 
     const mergePromise = async () => {
-      const mergedMember = {
-        ...primaryMember,
-      };
-      // Apply resolved conflict
-      Object.keys(conflictResolutions).forEach((field) => {
-        const choice = conflictResolutions[field];
-        if (field === "name") {
-          // Handle name field
-          mergedMember.name =
-            choice === "primary" ? primaryMember.name : selectedMember.name;
-        } else if (field === "email") {
-          // Handle email field
-          mergedMember.email =
-            choice === "primary" ? primaryMember.email : selectedMember.email;
-        } else if (field.startsWith("metadata.")) {
-          // Handle metadata fields
-          const metadataId = field.replace("metadata.", "");
-          if (!mergedMember.metadata) mergedMember.metadata = {};
-
-          const selectedValue =
-            choice === "primary"
-              ? primaryMember.metadata?.[metadataId]
-              : selectedMember.metadata?.[metadataId];
-
-          // Only assign if value exists
-          if (selectedValue !== undefined) {
-            mergedMember.metadata[metadataId] = selectedValue;
-          }
-        }
-      });
-      // Merge not confictfields from selected member
-      if (selectedMember.metadata && metadata) {
-        if (!mergedMember.metadata) mergedMember.metadata = {};
-
-        metadata.forEach((m) => {
-          const primaryValue = primaryMember.metadata?.[m.id];
-          const selectedValue = selectedMember.metadata?.[m.id];
-
-          // If primary is empty but selected has a value, use selected value
-          if (!primaryValue && selectedValue && mergedMember.metadata) {
-            mergedMember.metadata[m.id] = selectedValue;
-          }
-        });
-      }
-
-      // Merge email if primary is empty but selected has one
-      if (!mergedMember.email && selectedMember.email) {
-        mergedMember.email = selectedMember.email;
-      }
-      // Update primary information
-      updateMember(primaryMember.docRef, mergedMember);
-
-      const replaceDuplicateMembers = (
-        members?: { member: DocumentReference; signInTime: Timestamp }[],
-        primaryMember?: DocumentReference,
-        secondaryMember?: DocumentReference,
-      ) => {
-        if (!members || members.length === 0) return [];
-        if (!primaryMember || !secondaryMember) return members;
-
-        const primaryPath = primaryMember.path;
-        const secondaryPath = secondaryMember.path;
-
-        const hasPrimary = members.some((m) => m.member.path === primaryPath);
-        const hasSecondary = members.some(
-          (m) => m.member.path === secondaryPath,
-        );
-
-        // Remove secondary member from the list
-        let filtered = members.filter((m) => m.member.path !== secondaryPath);
-
-        // If only secondary was present (not primary), add primary member
-        if (hasSecondary && !hasPrimary) {
-          // Use the secondary's sign-in time for the primary member
-          const secondaryEntry = members.find(
-            (m) => m.member.path === secondaryPath,
-          );
-          filtered.push({
-            member: primaryMember,
-            signInTime: secondaryEntry?.signInTime || Timestamp.now(),
-          });
-        }
-
-        return filtered;
-      };
-
-      const replacePrimarySecondary = async (
-        primaryMember: DocumentReference,
-        secondaryMember: DocumentReference,
-      ) => {
-        for (const groupId of [
-          "ccSgQTXvLRnin0OjwvRM", // UNSW
-          "CZHRnKJ8SDnfMIw64WJu", // MCQ
-          "MUSmSaufEfgdJUX4Kx4G", // USYD
-          "wrsDV3XfwQB4RD7BxKD2", // UTS
-          // "bhaiAKXThkH9GbxpjZrd", // test group
-        ]) {
-          const events = await getDocs(
-            collection(firestore, "groups", groupId, "events"),
-          );
-
-          for (const e of events.docs) {
-            // For each event, replaces secondary member with primary member
-            await updateDoc(doc(firestore, "groups", groupId, "events", e.id), {
-              members: replaceDuplicateMembers(
-                e.data().members,
-                primaryMember,
-                secondaryMember,
-              ),
-            });
-          }
-        }
-      };
-      await replacePrimarySecondary(
-        primaryMember.docRef,
-        selectedMember.docRef,
+      const mergedMember = buildMergedMember(
+        primaryMember,
+        selectedMember,
+        conflictResolutions,
+        metadata,
       );
 
-      deleteMember(selectedMember.docRef);
+      await mergeMembers(
+        primaryMember.docRef,
+        selectedMember.docRef,
+        mergedMember,
+      );
     };
 
     try {
@@ -284,13 +119,6 @@ export default function MergeMember({
     setShowConflicts(false);
     setConflictResolutions({});
     setLoading(false);
-  };
-
-  const getMetadataDisplayValue = (metadataItem: any, value: string) => {
-    if (metadataItem.type === "select") {
-      return (metadataItem as MetadataSelectModel).values[value] || value;
-    }
-    return value;
   };
 
   const conflicts = selectedMember ? detectConflicts() : [];

--- a/frontend/src/lib/merge.ts
+++ b/frontend/src/lib/merge.ts
@@ -1,0 +1,265 @@
+import { MemberModel } from "@/models/Member";
+import {
+  MetadataInputModel,
+  MetadataSelectModel,
+} from "@/models/Metadata";
+import { updateMember, deleteMember } from "@/lib/members";
+import {
+  collection,
+  DocumentReference,
+  getDocs,
+  query,
+  Timestamp,
+  updateDoc,
+  where,
+  doc,
+} from "firebase/firestore";
+import { firestore } from "@/lib/firebase";
+import { universityIds } from "@/models/University";
+import { currentSOWYear } from "@/helper/Time";
+
+export interface MergeConflict {
+  field: string;
+  label: string;
+  primaryValue: string;
+  selectedValue: string;
+}
+
+export type ConflictResolutions = {
+  [key: string]: "primary" | "selected";
+};
+
+/**
+ * Detect conflicting fields between two members.
+ */
+export function detectConflicts(
+  primaryMember: MemberModel,
+  selectedMember: MemberModel,
+  metadata?: (MetadataInputModel | MetadataSelectModel)[] | null,
+): MergeConflict[] {
+  const conflicts: MergeConflict[] = [];
+
+  // check name conflict
+  if (
+    primaryMember.name &&
+    selectedMember.name &&
+    primaryMember.name !== selectedMember.name
+  ) {
+    conflicts.push({
+      field: "name",
+      label: "Name",
+      primaryValue: primaryMember.name,
+      selectedValue: selectedMember.name,
+    });
+  }
+
+  // Check email conflict
+  if (
+    primaryMember.email &&
+    selectedMember.email &&
+    primaryMember.email !== selectedMember.email
+  ) {
+    conflicts.push({
+      field: "email",
+      label: "Email",
+      primaryValue: primaryMember.email,
+      selectedValue: selectedMember.email,
+    });
+  }
+
+  // Check metadata conflicts
+  if (metadata) {
+    metadata.forEach((m) => {
+      const primaryValue = primaryMember.metadata?.[m.id];
+      const selectedValue = selectedMember.metadata?.[m.id];
+
+      if (primaryValue && selectedValue && primaryValue !== selectedValue) {
+        conflicts.push({
+          field: `metadata.${m.id}`,
+          label: m.key,
+          primaryValue: getMetadataDisplayValue(m, primaryValue),
+          selectedValue: getMetadataDisplayValue(m, selectedValue),
+        });
+      }
+    });
+  }
+
+  return conflicts;
+}
+
+/**
+ * Build a merged member from primary + selected, applying conflict resolutions
+ * and filling in empty fields from the selected member.
+ */
+export function buildMergedMember(
+  primaryMember: MemberModel,
+  selectedMember: MemberModel,
+  conflictResolutions: ConflictResolutions,
+  metadata?: (MetadataInputModel | MetadataSelectModel)[] | null,
+): MemberModel {
+  const mergedMember = {
+    ...primaryMember,
+  };
+
+  // Apply resolved conflicts
+  Object.keys(conflictResolutions).forEach((field) => {
+    const choice = conflictResolutions[field];
+    if (field === "name") {
+      mergedMember.name =
+        choice === "primary" ? primaryMember.name : selectedMember.name;
+    } else if (field === "email") {
+      mergedMember.email =
+        choice === "primary" ? primaryMember.email : selectedMember.email;
+    } else if (field.startsWith("metadata.")) {
+      const metadataId = field.replace("metadata.", "");
+      if (!mergedMember.metadata) mergedMember.metadata = {};
+
+      const selectedValue =
+        choice === "primary"
+          ? primaryMember.metadata?.[metadataId]
+          : selectedMember.metadata?.[metadataId];
+
+      if (selectedValue !== undefined) {
+        mergedMember.metadata[metadataId] = selectedValue;
+      }
+    }
+  });
+
+  // Merge non-conflict metadata fields from selected member
+  if (selectedMember.metadata && metadata) {
+    if (!mergedMember.metadata) mergedMember.metadata = {};
+
+    metadata.forEach((m) => {
+      const primaryValue = primaryMember.metadata?.[m.id];
+      const selectedValue = selectedMember.metadata?.[m.id];
+
+      // If primary is empty but selected has a value, use selected value
+      if (!primaryValue && selectedValue && mergedMember.metadata) {
+        mergedMember.metadata[m.id] = selectedValue;
+      }
+    });
+  }
+
+  // Merge email if primary is empty but selected has one
+  if (!mergedMember.email && selectedMember.email) {
+    mergedMember.email = selectedMember.email;
+  }
+
+  return mergedMember;
+}
+
+/**
+ * Replace secondary member references with primary in an event's member list.
+ * If both are present, the secondary is removed (primary stays).
+ * If only secondary is present, it is replaced with primary using secondary's sign-in time.
+ */
+function replaceDuplicateMembers(
+  members: { member: DocumentReference; signInTime: Timestamp }[] | undefined,
+  primaryMemberRef: DocumentReference,
+  secondaryMemberRef: DocumentReference,
+): {
+  changed: boolean;
+  members: { member: DocumentReference; signInTime: Timestamp }[];
+} {
+  if (!members || members.length === 0)
+    return { changed: false, members: [] };
+
+  const primaryPath = primaryMemberRef.path;
+  const secondaryPath = secondaryMemberRef.path;
+
+  const hasPrimary = members.some((m) => m.member.path === primaryPath);
+  const hasSecondary = members.some((m) => m.member.path === secondaryPath);
+
+  if (!hasSecondary) {
+    // Secondary not in this event — no changes needed
+    return { changed: false, members };
+  }
+
+  // Remove secondary member from the list
+  let filtered = members.filter((m) => m.member.path !== secondaryPath);
+
+  // If only secondary was present (not primary), add primary member
+  if (!hasPrimary) {
+    const secondaryEntry = members.find(
+      (m) => m.member.path === secondaryPath,
+    );
+    filtered.push({
+      member: primaryMemberRef,
+      signInTime: secondaryEntry?.signInTime || Timestamp.now(),
+    });
+  }
+
+  return { changed: true, members: filtered };
+}
+
+/**
+ * Get the SOW year date boundaries.
+ * SOW year N runs from Oct 1 of year N-1 to Sep 30 of year N.
+ */
+function getSOWYearBoundaries(): { start: Date; end: Date } {
+  const sowYear = currentSOWYear;
+  const start = new Date(sowYear - 1, 9, 1); // Oct 1 of previous year
+  const end = new Date(sowYear, 8, 30, 23, 59, 59, 999); // Sep 30 end of day
+  return { start, end };
+}
+
+/**
+ * Execute the full merge: update primary member, replace references in all
+ * events within the current SOW year across all groups, then delete secondary.
+ */
+export async function mergeMembers(
+  primaryMemberRef: DocumentReference,
+  secondaryMemberRef: DocumentReference,
+  mergedMember: MemberModel,
+): Promise<void> {
+  // Update primary member with merged data
+  await updateMember(primaryMemberRef, mergedMember);
+
+  const { start, end } = getSOWYearBoundaries();
+  const startTimestamp = Timestamp.fromDate(start);
+  const endTimestamp = Timestamp.fromDate(end);
+
+  // Iterate all groups and replace secondary member references in events
+  const groupIds = Object.values(universityIds);
+
+  for (const groupId of groupIds) {
+    const eventsQuery = query(
+      collection(firestore, "groups", groupId, "events"),
+      where("dateStart", ">=", startTimestamp),
+      where("dateStart", "<=", endTimestamp),
+    );
+
+    const events = await getDocs(eventsQuery);
+
+    for (const e of events.docs) {
+      const result = replaceDuplicateMembers(
+        e.data().members,
+        primaryMemberRef,
+        secondaryMemberRef,
+      );
+
+      // Only write if the member list actually changed
+      if (result.changed) {
+        await updateDoc(doc(firestore, "groups", groupId, "events", e.id), {
+          members: result.members,
+        });
+      }
+    }
+  }
+
+  // Delete secondary member
+  await deleteMember(secondaryMemberRef);
+}
+
+/**
+ * Get display value for a metadata field (resolves select labels).
+ */
+export function getMetadataDisplayValue(
+  metadataItem: MetadataInputModel | MetadataSelectModel,
+  value: string,
+): string {
+  if (metadataItem.type === "select") {
+    return (metadataItem as MetadataSelectModel).values[value] || value;
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Extracts merge business logic from MergeMember.tsx into a new merge.ts module, fixing several bugs in the process.

## Changes

### New file: merge.ts
- `detectConflicts()` — detects name, email, and metadata conflicts between two members
- `buildMergedMember()` — builds the merged member object, applying conflict resolutions and filling empty fields from the secondary member
- `mergeMembers()` — executes the full merge: updates primary member, replaces attendance references across all groups' events within the current SOW year, then deletes the secondary member
- `getMetadataDisplayValue()` — resolves select metadata labels for display
- Exported types: `MergeConflict`, `ConflictResolutions`

### Updated: MergeMember.tsx
- Removed all inline merge logic and direct Firestore imports
- Now imports and calls functions from merge.ts
- UI and state management unchanged

## Bug Fixes

| Bug | Before | After |
|-----|--------|-------|
| Missing `await` on `updateMember` | Fire-and-forget, could race or fail silently | `await updateMember(...)` |
| Missing `await` on `deleteMember` | Fire-and-forget, secondary could persist | `await deleteMember(...)` |
| Hardcoded group IDs (missing SOW group) | 4 hardcoded IDs, SOW group excluded | Uses `universityIds` constant (all 5 groups) |
| No SOW year filtering | Queried **all** events across all time | Filters events by `dateStart` within current SOW year (Oct 1 → Sep 30) |
| Unnecessary Firestore writes | Updated every event even if secondary member wasn't present | Only writes when the member list actually changed |

## No Behaviour Changes

- Conflict detection logic (name/email/metadata) — identical
- Conflict resolution and merged member building — identical
- `replaceDuplicateMembers` dedup logic — identical (both-present removes secondary; only-secondary replaces with primary using secondary's sign-in time)
- All UI rendering, state management, and user flows — unchanged